### PR TITLE
fix: Dev ContainersのCIのタグ生成を修正

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -49,4 +49,5 @@ jobs:
       - name: Build and run dev container task
         uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8
         with:
-          imageName: ghcr.io/${{ github.repository }}-devcontainer:${{ github.ref_name }}
+          imageName: ghcr.io/${{ github.repository }}-devcontainer
+          imageTag: ${{ github.ref_name }}


### PR DESCRIPTION
close #56 

## Summary (GitHub Copilot)
This pull request includes a small change to the `.github/workflows/devcontainer-ci.yml` file. The change involves splitting the `imageName` into `imageName` and `imageTag` for better clarity and management.

* [`.github/workflows/devcontainer-ci.yml`](diffhunk://#diff-410cfd47f6a2b3707b29679bd78f4565c00394d2478f4e9fb48eb6da1559a9a3L52-R53): Split the `imageName` into `imageName` and `imageTag`.