### PR TITLE
fix: bun run generateを修正

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsx build ./build.ts",
-    "generate": "bun run generate && bun run generate:typescript",
+    "generate": "bun run generate:json && bun run generate:typescript",
     "generate:json": "tsx src/bin/genereate.ts",
     "generate:typescript": "openapi-typescript ../generated/openapi/schema.json -o ../generated/openapi/schema.ts && prettier --write --semi=false ../generated/openapi/schema.ts",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",


### PR DESCRIPTION
close #76 

## Summary(GitHub Copilot)
This pull request includes a small but important change to the `backend/package.json` file. The change modifies the `generate` script to run `generate:json` instead of `generate`.

* [`backend/package.json`](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L6-R6): Updated the `generate` script to use `generate:json` instead of `generate`.