### PR TITLE
feat(backend): APIの各エンドポイントのparamsのidを数値に変更

### DIFF
--- a/backend/src/api/paths/problems.ts
+++ b/backend/src/api/paths/problems.ts
@@ -6,14 +6,15 @@ const app = new OpenAPIHono()
 
 // パラメータスキーマの定義
 const IdParam = z.object({
-  id: z
-    .string()
-    .min(1)
+  problemId: z
+    .number()
+    .int()
+    .nonnegative()
     .openapi({
-      example: "1",
+      example: 1,
       param: {
         in: "path",
-        name: "id",
+        name: "problemId",
       },
     }),
 })
@@ -66,7 +67,7 @@ const createProblemRoute = createRoute({
 const getProblemRoute = createRoute({
   method: "get",
   operationId: "getProblemById",
-  path: "/problems/{id}",
+  path: "/problems/{problemId}",
   request: {
     params: IdParam,
   },
@@ -90,7 +91,7 @@ const getProblemRoute = createRoute({
 const updateProblemRoute = createRoute({
   method: "put",
   operationId: "updateProblem",
-  path: "/problems/{id}",
+  path: "/problems/{problemId}",
   request: {
     body: {
       content: {
@@ -121,7 +122,7 @@ const updateProblemRoute = createRoute({
 const deleteProblemRoute = createRoute({
   method: "delete",
   operationId: "deleteProblem",
-  path: "/problems/{id}",
+  path: "/problems/{problemId}",
   request: {
     params: IdParam,
   },
@@ -140,7 +141,7 @@ const deleteProblemRoute = createRoute({
 const submitProgramRoute = createRoute({
   method: "post",
   operationId: "submitProgram",
-  path: "/problems/{id}/submit",
+  path: "/problems/{problemId}/submit",
   request: {
     body: {
       content: {
@@ -171,7 +172,7 @@ const submitProgramRoute = createRoute({
 const getSubmissionsRoute = createRoute({
   method: "get",
   operationId: "getSubmissions",
-  path: "/problems/{id}/submissions",
+  path: "/problems/{problemId}/submissions",
   request: {
     params: IdParam,
   },
@@ -218,11 +219,11 @@ app.openapi(createProblemRoute, (c) => {
 })
 
 app.openapi(getProblemRoute, (c) => {
-  const { id } = c.req.valid("param")
+  const { problemId } = c.req.valid("param")
   // TODO: 実際のデータベースクエリを実装
   const problem: z.infer<typeof schemas.Problem> = {
     body: "この問題の本文です。",
-    id: parseInt(id),
+    id: problemId,
     supported_languages: [{ name: "Python", version: "3.9" }],
     test_cases: [{ input: "入力例", output: "出力例" }],
     title: "サンプル問題",
@@ -231,12 +232,12 @@ app.openapi(getProblemRoute, (c) => {
 })
 
 app.openapi(updateProblemRoute, (c) => {
-  const { id } = c.req.valid("param")
+  const { problemId } = c.req.valid("param")
   const updateData = c.req.valid("json")
   // TODO: 実際のデータベース更新処理を実装
   const updatedProblem: z.infer<typeof schemas.Problem> = {
     body: updateData.body ?? "更新された本文",
-    id: parseInt(id),
+    id: problemId,
     supported_languages: updateData.supported_languages ?? [
       { name: "JavaScript", version: "ES2021" },
     ],
@@ -254,13 +255,13 @@ app.openapi(deleteProblemRoute, (c) => {
 })
 
 app.openapi(submitProgramRoute, (c) => {
-  const { id } = c.req.valid("param")
+  const { problemId } = c.req.valid("param")
   // TODO: 実際の提出処理とジャッジ処理を実装
   const createdSubmission: z.infer<typeof schemas.Submission> = {
     code: "print('Hello, World!')",
     id: Date.now(),
     language: { name: "Python", version: "3.9" },
-    problem_id: parseInt(id),
+    problem_id: problemId,
     result: { message: "テストケースにパスしました", status: "Accepted" },
     student_id: 1, // 仮の学生ID
     test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],
@@ -269,14 +270,14 @@ app.openapi(submitProgramRoute, (c) => {
 })
 
 app.openapi(getSubmissionsRoute, (c) => {
-  const { id } = c.req.valid("param")
+  const { problemId } = c.req.valid("param")
   // TODO: 実際のデータベースクエリを実装
   const submissions: z.infer<typeof schemas.Submission>[] = [
     {
       code: "print('Hello, World!')",
       id: 1,
       language: { name: "Python", version: "3.9" },
-      problem_id: parseInt(id),
+      problem_id: problemId,
       result: { message: "テストケースにパスしました", status: "Accepted" },
       student_id: 1,
       test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],

--- a/backend/src/api/paths/submissions.ts
+++ b/backend/src/api/paths/submissions.ts
@@ -6,14 +6,15 @@ const app = new OpenAPIHono()
 
 // パラメータスキーマの定義
 const SubmissionIdParam = z.object({
-  id: z
-    .string()
-    .min(1)
+  submissionId: z
+    .number()
+    .int()
+    .nonnegative()
     .openapi({
-      example: "1",
+      example: 1,
       param: {
         in: "path",
-        name: "id",
+        name: "submissionId",
       },
     }),
 })
@@ -39,7 +40,7 @@ const getSubmissionsRoute = createRoute({
 const getSubmissionByIdRoute = createRoute({
   method: "get",
   operationId: "getSubmissionById",
-  path: "/submissions/{id}",
+  path: "/submissions/{submissionId}",
   request: {
     params: SubmissionIdParam,
   },
@@ -78,11 +79,11 @@ app.openapi(getSubmissionsRoute, (c) => {
 })
 
 app.openapi(getSubmissionByIdRoute, (c) => {
-  const { id } = c.req.valid("param")
+  const { submissionId } = c.req.valid("param")
   // TODO: 実際のデータベースクエリを実装
   const submission: z.infer<typeof Submission> = {
     code: "print('Hello, World!')",
-    id: parseInt(id),
+    id: submissionId,
     language: { name: "Python", version: "3.9" },
     problem_id: 1,
     result: { message: "テストケースにパスしました", status: "Accepted" },

--- a/generated/openapi/schema.json
+++ b/generated/openapi/schema.json
@@ -283,7 +283,7 @@
         }
       }
     },
-    "/api/problems/{id}": {
+    "/api/problems/{problemId}": {
       "get": {
         "operationId": "getProblemById",
         "summary": "問題の詳細を取得する",
@@ -293,13 +293,13 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "1"
+              "type": "integer",
+              "minimum": 0,
+              "example": 1
             },
             "required": true,
             "in": "path",
-            "name": "id"
+            "name": "problemId"
           }
         ],
         "responses": {
@@ -327,13 +327,13 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "1"
+              "type": "integer",
+              "minimum": 0,
+              "example": 1
             },
             "required": true,
             "in": "path",
-            "name": "id"
+            "name": "problemId"
           }
         ],
         "requestBody": {
@@ -370,13 +370,13 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "1"
+              "type": "integer",
+              "minimum": 0,
+              "example": 1
             },
             "required": true,
             "in": "path",
-            "name": "id"
+            "name": "problemId"
           }
         ],
         "responses": {
@@ -389,7 +389,7 @@
         }
       }
     },
-    "/api/problems/{id}/submit": {
+    "/api/problems/{problemId}/submit": {
       "post": {
         "operationId": "submitProgram",
         "summary": "問題に対してプログラムを提出する",
@@ -399,13 +399,13 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "1"
+              "type": "integer",
+              "minimum": 0,
+              "example": 1
             },
             "required": true,
             "in": "path",
-            "name": "id"
+            "name": "problemId"
           }
         ],
         "requestBody": {
@@ -434,7 +434,7 @@
         }
       }
     },
-    "/api/problems/{id}/submissions": {
+    "/api/problems/{problemId}/submissions": {
       "get": {
         "operationId": "getSubmissions",
         "summary": "問題に対する提出一覧を取得する",
@@ -444,13 +444,13 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "1"
+              "type": "integer",
+              "minimum": 0,
+              "example": 1
             },
             "required": true,
             "in": "path",
-            "name": "id"
+            "name": "problemId"
           }
         ],
         "responses": {
@@ -497,7 +497,7 @@
         }
       }
     },
-    "/api/submissions/{id}": {
+    "/api/submissions/{submissionId}": {
       "get": {
         "operationId": "getSubmissionById",
         "summary": "提出の詳細を取得する",
@@ -507,13 +507,13 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "1"
+              "type": "integer",
+              "minimum": 0,
+              "example": 1
             },
             "required": true,
             "in": "path",
-            "name": "id"
+            "name": "submissionId"
           }
         ],
         "responses": {

--- a/generated/openapi/schema.ts
+++ b/generated/openapi/schema.ts
@@ -22,7 +22,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/problems/{id}": {
+  "/api/problems/{problemId}": {
     parameters: {
       query?: never
       header?: never
@@ -41,7 +41,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/problems/{id}/submit": {
+  "/api/problems/{problemId}/submit": {
     parameters: {
       query?: never
       header?: never
@@ -58,7 +58,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/problems/{id}/submissions": {
+  "/api/problems/{problemId}/submissions": {
     parameters: {
       query?: never
       header?: never
@@ -92,7 +92,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/submissions/{id}": {
+  "/api/submissions/{submissionId}": {
     parameters: {
       query?: never
       header?: never
@@ -227,7 +227,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        id: string
+        problemId: number
       }
       cookie?: never
     }
@@ -256,7 +256,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        id: string
+        problemId: number
       }
       cookie?: never
     }
@@ -289,7 +289,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        id: string
+        problemId: number
       }
       cookie?: never
     }
@@ -316,7 +316,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        id: string
+        problemId: number
       }
       cookie?: never
     }
@@ -349,7 +349,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        id: string
+        problemId: number
       }
       cookie?: never
     }
@@ -398,7 +398,7 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        id: string
+        submissionId: number
       }
       cookie?: never
     }


### PR DESCRIPTION
close #78 

## 変更点

- APIの各エンドポイントのparamsのidの型を数値に変更
- paramsの`id`を`problemId`もしくは`submissionId`など、明示的な名前に変更

## Summary

This pull request makes several changes to improve the consistency and clarity of parameter naming in the backend API routes. The main focus is on renaming the `id` parameter to more descriptive names like `problemId` and `submissionId`.

### Changes in `backend/src/api/paths/problems.ts`:

* Renamed `id` parameter to `problemId` in the `IdParam` schema definition. (`[backend/src/api/paths/problems.tsL9-R17](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL9-R17)`)
* Updated the path parameters from `{id}` to `{problemId}` in the `createProblemRoute`, `getProblemRoute`, `updateProblemRoute`, `deleteProblemRoute`, `submitProgramRoute`, and `getSubmissionsRoute` routes. (`[[1]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL69-R70)`, `[[2]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL93-R94)`, `[[3]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL124-R125)`, `[[4]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL143-R144)`, `[[5]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL174-R175)`)
* Adjusted the parameter extraction in the route handlers to use `problemId` instead of `id`. (`[[1]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL221-R226)`, `[[2]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL234-R240)`, `[[3]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL257-R264)`, `[[4]](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL272-R280)`)

### Changes in `backend/src/api/paths/submissions.ts`:

* Renamed `id` parameter to `submissionId` in the `SubmissionIdParam` schema definition. (`[backend/src/api/paths/submissions.tsL9-R17](diffhunk://#diff-5b17fdf8ab78aa2a7cb5cbe7883584f1638d969d15010469cf7b39cbb127b908L9-R17)`)
* Updated the path parameters from `{id}` to `{submissionId}` in the `getSubmissionByIdRoute` route. (`[backend/src/api/paths/submissions.tsL42-R43](diffhunk://#diff-5b17fdf8ab78aa2a7cb5cbe7883584f1638d969d15010469cf7b39cbb127b908L42-R43)`)
* Adjusted the parameter extraction in the route handler to use `submissionId` instead of `id`. (`[backend/src/api/paths/submissions.tsL81-R86](diffhunk://#diff-5b17fdf8ab78aa2a7cb5cbe7883584f1638d969d15010469cf7b39cbb127b908L81-R86)`)