### PR TITLE
feat(backend): 重複しているoperationIdの名前を変更

### DIFF
--- a/backend/src/api/paths/problems.ts
+++ b/backend/src/api/paths/problems.ts
@@ -169,9 +169,9 @@ const submitProgramRoute = createRoute({
   tags: ["problems"],
 })
 
-const getSubmissionsRoute = createRoute({
+const getSubmissionsByProblemIdRoute = createRoute({
   method: "get",
-  operationId: "getSubmissions",
+  operationId: "getSubmissionsByProblemId",
   path: "/problems/{problemId}/submissions",
   request: {
     params: IdParam,
@@ -269,7 +269,7 @@ app.openapi(submitProgramRoute, (c) => {
   return c.json(createdSubmission, 201)
 })
 
-app.openapi(getSubmissionsRoute, (c) => {
+app.openapi(getSubmissionsByProblemIdRoute, (c) => {
   const { problemId } = c.req.valid("param")
   // TODO: 実際のデータベースクエリを実装
   const submissions: z.infer<typeof schemas.Submission>[] = [

--- a/generated/openapi/schema.json
+++ b/generated/openapi/schema.json
@@ -436,7 +436,7 @@
     },
     "/api/problems/{problemId}/submissions": {
       "get": {
-        "operationId": "getSubmissions",
+        "operationId": "getSubmissionsByProblemId",
         "summary": "問題に対する提出一覧を取得する",
         "tags": [
           "problems"

--- a/generated/openapi/schema.ts
+++ b/generated/openapi/schema.ts
@@ -66,7 +66,7 @@ export interface paths {
       cookie?: never
     }
     /** 問題に対する提出一覧を取得する */
-    get: operations["getSubmissions"]
+    get: operations["getSubmissionsByProblemId"]
     put?: never
     post?: never
     delete?: never
@@ -344,7 +344,7 @@ export interface operations {
       }
     }
   }
-  getSubmissions: {
+  getSubmissionsByProblemId: {
     parameters: {
       query?: never
       header?: never


### PR DESCRIPTION
close #81 

## Summary

This pull request includes changes to improve the clarity and specificity of the route names in the `backend/src/api/paths/problems.ts` file. The most important changes involve renaming a route and its associated operation ID for better readability and maintainability.

Changes to route names:

* [`backend/src/api/paths/problems.ts`](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL172-R174): Renamed `getSubmissionsRoute` to `getSubmissionsByProblemIdRoute` and updated the `operationId` to match the new route name.
* [`backend/src/api/paths/problems.ts`](diffhunk://#diff-82eb8bfb539ca0b576c734db8d95ca513a204c43ca4e9f23f5873ed698bc28dcL272-R272): Updated the `app.openapi` call to use the new route name `getSubmissionsByProblemIdRoute`.