### PR TITLE
feat(backend): SubmissionCreateコンポーネントに`code`、`language`プロパティを追加

### DIFF
--- a/backend/src/api/components/schemas.ts
+++ b/backend/src/api/components/schemas.ts
@@ -63,8 +63,9 @@ export const Submission = z
   })
   .openapi("Submission")
 
-export const SubmissionCreate = z
-  .object({
-    problem_id: z.number().int().nonnegative(),
-  })
-  .openapi("SubmissionCreate")
+export const SubmissionCreate = Submission.omit({
+  id: true,
+  result: true,
+  student_id: true,
+  test_results: true,
+}).openapi("SubmissionCreate")

--- a/generated/openapi/schema.json
+++ b/generated/openapi/schema.json
@@ -218,12 +218,20 @@
       "SubmissionCreate": {
         "type": "object",
         "properties": {
+          "code": {
+            "type": "string"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
           "problem_id": {
             "type": "integer",
             "minimum": 0
           }
         },
         "required": [
+          "code",
+          "language",
           "problem_id"
         ]
       }

--- a/generated/openapi/schema.ts
+++ b/generated/openapi/schema.ts
@@ -167,6 +167,8 @@ export interface components {
       test_results: components["schemas"]["TestResult"][]
     }
     SubmissionCreate: {
+      code: string
+      language: components["schemas"]["Language"]
       problem_id: number
     }
   }


### PR DESCRIPTION
close #83 

## Summary

This pull request includes a change to the `SubmissionCreate` schema in the `backend/src/api/components/schemas.ts` file to simplify its definition by reusing the `Submission` schema and omitting certain fields.

Schema refactoring:

* [`backend/src/api/components/schemas.ts`](diffhunk://#diff-6f03776faa42cc0916116f267f2ddd1c990214aa0c0f4a24e8beb41c82871f80L66-R71): Modified the `SubmissionCreate` schema to reuse the `Submission` schema and omit the `id`, `result`, `student_id`, and `test_results` fields.