### PR TITLE
feat(backend): プログラム提出時に、提出時刻を保持するようスキーマを変更

### DIFF
--- a/backend/src/api/components/schemas.ts
+++ b/backend/src/api/components/schemas.ts
@@ -59,6 +59,7 @@ export const Submission = z
     problem_id: z.number().int().nonnegative(),
     result: SubmissionResult,
     student_id: z.number().int().nonnegative(),
+    submitted_at: z.string().datetime(),
     test_results: z.array(TestResult),
   })
   .openapi("Submission")
@@ -67,5 +68,6 @@ export const SubmissionCreate = Submission.omit({
   id: true,
   result: true,
   student_id: true,
+  submitted_at: true,
   test_results: true,
 }).openapi("SubmissionCreate")

--- a/backend/src/api/paths/problems.ts
+++ b/backend/src/api/paths/problems.ts
@@ -264,6 +264,7 @@ app.openapi(submitProgramRoute, (c) => {
     problem_id: problemId,
     result: { message: "テストケースにパスしました", status: "Accepted" },
     student_id: 1, // 仮の学生ID
+    submitted_at: new Date().toISOString(),
     test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],
   }
   return c.json(createdSubmission, 201)
@@ -280,6 +281,7 @@ app.openapi(getSubmissionsByProblemIdRoute, (c) => {
       problem_id: problemId,
       result: { message: "テストケースにパスしました", status: "Accepted" },
       student_id: 1,
+      submitted_at: new Date().toISOString(),
       test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],
     },
   ]

--- a/backend/src/api/paths/submissions.ts
+++ b/backend/src/api/paths/submissions.ts
@@ -72,6 +72,7 @@ app.openapi(getSubmissionsRoute, (c) => {
       problem_id: 1,
       result: { message: "テストケースにパスしました", status: "Accepted" },
       student_id: 1,
+      submitted_at: new Date().toISOString(),
       test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],
     },
   ]
@@ -88,6 +89,7 @@ app.openapi(getSubmissionByIdRoute, (c) => {
     problem_id: 1,
     result: { message: "テストケースにパスしました", status: "Accepted" },
     student_id: 1,
+    submitted_at: new Date().toISOString(),
     test_results: [{ message: "正解", status: "Passed", test_case_id: 1 }],
   }
   return c.json(submission)

--- a/generated/openapi/schema.json
+++ b/generated/openapi/schema.json
@@ -198,6 +198,10 @@
             "type": "integer",
             "minimum": 0
           },
+          "submitted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
           "test_results": {
             "type": "array",
             "items": {
@@ -212,6 +216,7 @@
           "problem_id",
           "result",
           "student_id",
+          "submitted_at",
           "test_results"
         ]
       },

--- a/generated/openapi/schema.ts
+++ b/generated/openapi/schema.ts
@@ -164,6 +164,8 @@ export interface components {
       problem_id: number
       result: components["schemas"]["SubmissionResult"]
       student_id: number
+      /** Format: date-time */
+      submitted_at: string
       test_results: components["schemas"]["TestResult"][]
     }
     SubmissionCreate: {


### PR DESCRIPTION
close #89 

## Summary

This pull request introduces the `submitted_at` field to the `Submission` schema and ensures it is included in various API endpoints. The key changes involve updating the schema definition and modifying the API routes to include this new field.

Schema updates:

* Added `submitted_at` field to the `Submission` schema in `backend/src/api/components/schemas.ts`.
* Included `submitted_at` in the `SubmissionCreate` schema by omitting it from the `Submission` schema in `backend/src/api/components/schemas.ts`.

API route updates:

* Added `submitted_at` with the current timestamp to the `submitProgramRoute` in `backend/src/api/paths/problems.ts`.
* Added `submitted_at` with the current timestamp to the `getSubmissionsByProblemIdRoute` in `backend/src/api/paths/problems.ts`.
* Added `submitted_at` with the current timestamp to the `getSubmissionsRoute` in `backend/src/api/paths/submissions.ts`.
* Added `submitted_at` with the current timestamp to the `getSubmissionByIdRoute` in `backend/src/api/paths/submissions.ts`.