### PR TITLE
feat(backend): `getProblemsRoute`と`createProblemRoute`を実装

### DIFF
--- a/backend/src/api/paths/problems.ts
+++ b/backend/src/api/paths/problems.ts
@@ -6,36 +6,6 @@ import * as schemas from "../components/schemas"
 const prisma = new PrismaClient()
 const app = new OpenAPIHono()
 
-interface ProblemWithRelations {
-  body: string
-  createdAt: Date
-  id: number
-  supportedLanguages: {
-    createdAt: Date
-    id: number
-    language: {
-      createdAt: Date
-      name: string
-      updatedAt: Date
-      version: string
-    }
-    languageName: string
-    languageVersion: string
-    problemId: null | number
-    updatedAt: Date
-  }[]
-  testCases: {
-    createdAt: Date
-    id: number
-    input: string
-    output: string
-    problemId: number
-    updatedAt: Date
-  }[]
-  title: string
-  updatedAt: Date
-}
-
 // パラメータスキーマの定義
 const IdParam = z.object({
   problemId: z
@@ -238,21 +208,17 @@ app.openapi(getProblemsRoute, async (c) => {
     },
   })
 
-  const formattedProblems = problems.map((problem: ProblemWithRelations) => ({
+  const formattedProblems = problems.map((problem) => ({
     body: problem.body,
     id: problem.id,
-    supported_languages: problem.supportedLanguages.map(
-      (supportedLang: ProblemWithRelations["supportedLanguages"][0]) => ({
-        name: supportedLang.language.name,
-        version: supportedLang.language.version,
-      }),
-    ),
-    test_cases: problem.testCases.map(
-      (testCase: ProblemWithRelations["testCases"][0]) => ({
-        input: testCase.input,
-        output: testCase.output,
-      }),
-    ),
+    supported_languages: problem.supportedLanguages.map((supportedLang) => ({
+      name: supportedLang.language.name,
+      version: supportedLang.language.version,
+    })),
+    test_cases: problem.testCases.map((testCase) => ({
+      input: testCase.input,
+      output: testCase.output,
+    })),
     title: problem.title,
   }))
 
@@ -301,18 +267,14 @@ app.openapi(createProblemRoute, async (c) => {
   const formattedProblem = {
     body: createdProblem.body,
     id: createdProblem.id,
-    supported_languages: createdProblem.supportedLanguages.map(
-      (lang: ProblemWithRelations["supportedLanguages"][0]) => ({
-        name: lang.language.name,
-        version: lang.language.version,
-      }),
-    ),
-    test_cases: createdProblem.testCases.map(
-      (testCase: ProblemWithRelations["testCases"][0]) => ({
-        input: testCase.input,
-        output: testCase.output,
-      }),
-    ),
+    supported_languages: createdProblem.supportedLanguages.map((lang) => ({
+      name: lang.language.name,
+      version: lang.language.version,
+    })),
+    test_cases: createdProblem.testCases.map((testCase) => ({
+      input: testCase.input,
+      output: testCase.output,
+    })),
     title: createdProblem.title,
   }
   return c.json(formattedProblem, 201)


### PR DESCRIPTION
close #124, #125 

## 確認事項

### 新しい問題を作成する
入力
```
curl --request POST \
  --url http://localhost:3000/api/problems \
  --header 'Content-Type: application/json' \
  --data '{
  "body": "任意の自然数が2つ与えられたら加算する。",
  "supported_languages": [
    {
      "name": "Rust",
      "version": "2021"
    }
  ],
  "test_cases": [
    {
      "input": "3 5",
      "output": "8"
    }
  ],
  "title": "plus"
}'
```

- [ ] 上記の入力を行った場合以下の出力が確認できる

```
{
  "body": "任意の自然数が2つ与えられたら加算する。",
  "id": 1,
  "supported_languages": [
    {
      "name": "Rust",
      "version": "2021"
    }
  ],
  "test_cases": [
    {
      "input": "3 5",
      "output": "8"
    }
  ],
  "title": "plus"
}
```

### 問題一覧を出力する

- [ ] 上記の入力を行った場合以下の出力が確認できる

```
[
  {
    "body": "任意の自然数が2つ与えられたら加算する。",
    "id": 1,
    "supported_languages": [
      {
        "name": "Rust",
        "version": "2021"
      }
    ],
    "test_cases": [
      {
        "input": "3 5",
        "output": "8"
      }
    ],
    "title": "plus"
  }
]
```

## Summary
This pull request includes significant updates to the `backend/src/api/paths/problems.ts` file, primarily focusing on integrating Prisma for database operations and implementing actual database queries for problem retrieval and creation.

### Integration of Prisma:

* **Prisma Client Initialization**: Added initialization of `PrismaClient` to interact with the database. (`backend/src/api/paths/problems.ts`)

### Database Operations:

* **Fetch Problems from Database**: Replaced the placeholder code with an actual database query using Prisma to fetch problems, including related `supportedLanguages` and `testCases`. (`backend/src/api/paths/problems.ts`)
* **Create Problem in Database**: Implemented the logic to create a new problem in the database with related `supportedLanguages` and `testCases` using Prisma. (`backend/src/api/paths/problems.ts`)