### PR TITLE
fix(backend): add prisma generate

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -109,6 +109,8 @@ jobs:
         uses: jdx/mise-action@f8dfbcc150159126838e44b882bf34bd98fd90f3 # v2.1.0
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      - name: Prisma generate
+        run: bun run prisma generate
       - name: Generate OpenAPI Schema
         run: bun run generate
       - name: Vertify the generated OpenAPI Schema is up-to-date


### PR DESCRIPTION
close #137 
This pull request includes updates to the CI workflow to ensure that the Prisma client is generated before running other tasks.

Changes in CI workflow:

* [`.github/workflows/backend-ci.yml`](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bR112-R113): Added a step to run `bun run prisma generate` to ensure Prisma client is generated.