### PR TITLE
fix(backend): `type-check`にて`prisma generate`が実行されるように変更

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -92,6 +92,8 @@ jobs:
         uses: jdx/mise-action@f8dfbcc150159126838e44b882bf34bd98fd90f3 # v2.1.0
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      - name: Prisma generate
+        run: bun run prisma generate
       - name: Check type
         run: bun run type-check
 


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/backend-ci.yml` file. The change adds a step to generate Prisma client code during the CI process.

* [`.github/workflows/backend-ci.yml`](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bR95-R96): Added a `Prisma generate` step to run `bun run prisma generate` after installing dependencies.